### PR TITLE
fix unexpected parameter to super()

### DIFF
--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -46,11 +46,11 @@ module WPScan
       end
 
       def before_scan
-        output('banner')
+        output('banner') unless parsed_options[:no_banner]
 
         update_db if update_db_required?
 
-        super(false) # disable banner output
+        super
 
         load_server_module
 


### PR DESCRIPTION
Recent change to wpscanteam/CMSScanner removed this parameter and
replaced it with a command line option.

See https://github.com/wpscanteam/CMSScanner/commit/128867f6c3fcfe4b60c01422439dc16a0cc2e137